### PR TITLE
Less restrictive auto_factorize_df

### DIFF
--- a/R/bican.mccarroll.differentialexpression/R/variancePartition.R
+++ b/R/bican.mccarroll.differentialexpression/R/variancePartition.R
@@ -560,8 +560,10 @@ buildVariancePartitionModelFormula<-function (fixedVars, randVars) {
 auto_factorize_df <- function(df, factor_cols = NULL) {
     stopifnot(is.data.frame(df))
 
+    # intersect the user-provided factor_cols with the actual columns
+    # in the data frame
     if (!is.null(factor_cols)) {
-        stopifnot(all(factor_cols %in% names(df)))
+        factor_cols <- intersect(factor_cols, names(df))
     }
 
     convert_column <- function(col, col_name, factor_cols) {


### PR DESCRIPTION
Make auto_factorize_df a little less restricive - don't require the passed in auto_factorize columns exist in the dataframe